### PR TITLE
Chapter4: small update

### DIFF
--- a/chapter4/README.md
+++ b/chapter4/README.md
@@ -15,17 +15,17 @@ module type Kleisli =
 ```
 * Pure for Writer
 ```ocaml
-# let pure (type a) (x:a) = (x, "");;
+# let pure x = (x, "");;
 val pure : 'a -> 'a * string = <fun>
 ```
 * upCase for Writer
 ```ocaml
-# let up_case:(string -> string writer) = fun s -> (String.uppercase s, "up_case ")
+# let up_case : (string -> string writer) = fun s -> (String.uppercase s, "up_case ")
 val up_case : string -> string writer = <fun>
 ```
 * toWords for Writer
 ```ocaml
-# let to_words:(string -> string list writer) = fun s -> (String.split s ~on:' ', "to_words ")
+# let to_words : (string -> string list writer) = fun s -> (String.split s ~on:' ', "to_words ")
 val to_words : string -> string list writer = <fun>
 ```
 * Example Kleisli application


### PR DESCRIPTION
Neat. I have been undecided until the end if it is better to convert `Kleisli` to a (OCaml) functor or not, but I think at least for now this is more readable and direct.

`pure` doesn't really need type annotations, and if you want to annotate it, I'd rather do

```
let pure (x:'a) : 'a writer = (x, "")
```

The real OCaml way to deal with these abstractions would be to use a mli file or a module type to define the interface and hide the implementation details, but I don't think this is feasible for this.