### PR TITLE
chapte6: suggestions

### DIFF
--- a/chapter6/README.md
+++ b/chapter6/README.md
@@ -13,12 +13,12 @@ val swap : 'a * 'b -> 'b * 'a = <fun>
 ```
 * Types are different but elements are in one-to-one correspondence.
 ```ocaml
-# let alpha = function | ((a, b), c) -> (a, (b, c))
+# let alpha ((a, b), c) = (a, (b, c))
 val alpha : ('a * 'b) * 'c -> 'a * ('b * 'c) = <fun>
 ```
 * Invertible function Alpha.
 ```ocaml
-# let alpha_inv = function | (a, (b, c)) -> ((a, b), c)
+# let alpha_inv (a, (b, c)) = ((a, b), c)
 val alpha_inv : 'a * ('b * 'c) -> ('a * 'b) * 'c = <fun>
 ```
 * Unit type is the unit of the product
@@ -28,7 +28,7 @@ val alpha_inv : 'a * ('b * 'c) -> ('a * 'b) * 'c = <fun>
 ```
 * Isomorphism example
 ```ocaml
-# let rho = function | (a, ()) -> a
+# let rho (a, ()) = a
 val rho : 'a * unit -> 'a = <fun>
 ```
 ```ocaml
@@ -61,7 +61,7 @@ type stmt = Stmt of string * int
 ## Records
 * Problem in working with unnamed tuples
 ```ocaml
-# let starts_with_symbol = function | (name, symbol, _) -> String.is_prefix name ~prefix:symbol
+# let starts_with_symbol (name, symbol, _) = String.is_prefix name ~prefix:symbol
 val starts_with_symbol : string * string * 'a -> bool = <fun>
 ```
 * Element as a Record
@@ -74,20 +74,20 @@ type element =
 ```
 * The two representations are isomorphic.
 ```ocaml
-# let tuple_to_elem = function | (n, s, a) -> {name = n; symbol=s; atomic_number=a;}
+# let tuple_to_elem (name, symbol, atomic_number) = {name; symbol; atomic_number}
 val tuple_to_elem : string * string * int -> element = <fun>
 ```
 ```ocaml
-# let elem_to_tuple = function | {name; symbol; atomic_number} -> (name, symbol, atomic_number)
+# let elem_to_tuple {name; symbol; atomic_number} = (name, symbol, atomic_number)
 val elem_to_tuple : element -> string * string * int = <fun>
 ```
 ```ocaml
-# let atomic_number = function | {atomic_number} -> atomic_number
+# let atomic_number {atomic_number} = atomic_number
 val atomic_number : element -> int = <fun>
 ```
 * Using record syntax
 ```ocaml
-# let starts_with_symbol = function | {name;symbol;_;} -> String.is_prefix name ~prefix:symbol
+# let starts_with_symbol {name;symbol;_} = String.is_prefix name ~prefix:symbol
 val starts_with_symbol : element -> bool = <fun>
 ```
 * OCaml only allows special characters in the infix operator. So, the above function name cannot be applied be infix.


### PR DESCRIPTION
I have simplified some declaration unnecessarily using the `= function |` for pattern matching and simplified the pattern matching on records.

I think that it would be worth emphasising that ocaml has its own maybe and either types, but they are calles option and result (and in particular result is somewhat specialised for errors.