### PR TITLE
Chapter 21: small update (and drop unnecessary use of base)

### DIFF
--- a/chapter21/README.md
+++ b/chapter21/README.md
@@ -1,6 +1,7 @@
 # Monads and Effects
 ## Utilities used by code below
 ```ocaml
+let flip f x y = f y x
 module type Monad_Join =  sig
   type 'a m
   val join : 'a m m -> 'a m
@@ -38,13 +39,17 @@ end
 ```
 - Bind using join and fmap
 ```ocaml
-let ( >>= ) xs k = List.concat (List.map k xs)
+let ( >>= ) xs k = List_Monad.join (List.map k xs)
 ```
 - Triples in OCaml
 ```ocaml
+(* This requires the "gen" library,
+   after having installed them, execute
+   #require "gen";; *)
+
 module Pythagorean = struct
 
-  let (let*) = Fn.flip Gen.flat_map
+  let (let*) = flip Gen.flat_map
 
   let (let+) x f = Gen.map f x
 
@@ -61,14 +66,18 @@ end
 - guard for List
 ```ocaml
 let guard = function
-  true -> [()]
+  | true -> [()]
   | false -> []
 ```
 - Triples alternate
 ```ocaml
+(* This requires the "gen" library,
+   after having installed them, execute
+   #require "gen";; *)
+
 module Pythagorean = struct
 
-  let (let*) = Fn.flip Gen.flat_map
+  let (let*) = flip Gen.flat_map
 
   let (let+) x f = Gen.map f x
 


### PR DESCRIPTION
You can also simplify your prelude, you require core there but you only needed base (and now not even that). I think using Gen is a good idea here.

Also note that a mix of snake and camel case in module names and types is unusual. It is most common to see only camelcase, e.g. MonadJoin, ListMonad, ... I did not change because I don’t know if you had a particular reason for the choice. 